### PR TITLE
Remove invalid parameter

### DIFF
--- a/Dockerfile.prometheus.patch
+++ b/Dockerfile.prometheus.patch
@@ -7,11 +7,3 @@
  LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
  
  COPY prometheus                             /bin/prometheus
-@@ -17,6 +18,7 @@
- WORKDIR    /prometheus
- ENTRYPOINT [ "/bin/prometheus" ]
- CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
-+             "--storage.local.target-heap-size=104857600", \
-              "--storage.tsdb.path=/prometheus", \
-              "--web.console.libraries=/usr/share/prometheus/console_libraries", \
-              "--web.console.templates=/usr/share/prometheus/consoles" ]


### PR DESCRIPTION
According to the [Prometheus 2.0 Migration Guide](https://prometheus.io/docs/prometheus/2.0/migration/),
it now uses a new storage engine, so the `-storage.local.*` parameters
are no longer valid/required (fixes #8)